### PR TITLE
Fix types and API key check

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -145,7 +145,7 @@ const App: React.FC = () => {
     addNotification('提示詞已清空', 'success');
   };
 
-  const isApiKeyMissing = !process.env.API_KEY;
+  const isApiKeyMissing = !process.env.GEMINI_API_KEY;
 
   return (
     <>

--- a/types.ts
+++ b/types.ts
@@ -1,4 +1,4 @@
-
+import type { ReactNode } from 'react';
 export interface ImageRecord {
   id: string;
   prompt: string;
@@ -19,7 +19,7 @@ export interface Dimension {
   name: string;
   width: number;
   height: number;
-  icon: React.ReactNode;
+  icon: ReactNode;
 }
 
 export type NotificationType = 'success' | 'error';
@@ -29,3 +29,4 @@ export interface Notification {
   message: string;
   type: NotificationType;
 }
+


### PR DESCRIPTION
## Summary
- import ReactNode in `types.ts`
- use `GEMINI_API_KEY` for API key check in `App.tsx`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868586718cc8323985cdf4155731aeb